### PR TITLE
Flatpak

### DIFF
--- a/phoenicis-dist/src/flatpak/ld.so.conf
+++ b/phoenicis-dist/src/flatpak/ld.so.conf
@@ -1,0 +1,3 @@
+# Taken from https://github.com/flathub/com.valvesoftware.Steam/blob/47015a67c4a79a7dc98d29f79c31f00388a9801b/ld.so.conf
+include /run/flatpak/ld.so.conf.d/app-*-org.freedesktop.Platform.GL32.*.conf
+/app/lib/i386-linux-gnu

--- a/phoenicis-dist/src/flatpak/org.phoenicis.javafx.json
+++ b/phoenicis-dist/src/flatpak/org.phoenicis.javafx.json
@@ -10,6 +10,23 @@
     "org.freedesktop.Platform.Compat.i386": {
       "directory": "lib/i386-linux-gnu",
       "version": "18.08"
+    },
+    "org.freedesktop.Platform.Compat.i386.Debug": {
+      "directory": "lib/debug/lib/i386-linux-gnu",
+      "version": "18.08",
+      "no-autodownload": true
+    },
+    "org.freedesktop.Platform.GL32": {
+      "directory": "lib/i386-linux-gnu/GL",
+      "version": "1.4",
+      "versions": "18.08;1.4",
+      "subdirectories": true,
+      "no-autodownload": true,
+      "autodelete": false,
+      "add-ld-path": "lib",
+      "merge-dirs": "vulkan/icd.d;glvnd/egl_vendor.d",
+      "download-if": "active-gl-driver",
+      "enable-if": "active-gl-driver"
     }
   },
   "command": "phoenicis-javafx",


### PR DESCRIPTION
Hi @plata 
I tried to add GL32 and 32bit debug extensions. 

First I have noticed, that `ld.so.conf` is missing.

I had no problems installing it, but I was not able to use it to install any app.